### PR TITLE
feat: 意図的にエラーログを出力するページを追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,44 @@
 #!/usr/bin/env python
-from flask import Flask
-from flask import render_template
+# -*- coding: utf-8 -*-
+
 import random
 import os
 import argparse
+from flask import Flask
+from flask import render_template
+from logging.config import dictConfig
 
+dictConfig({
+    'version': 1,
+    'formatters': {'default': {
+        'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+    }},
+    'handlers': {'wsgi': {
+        'class': 'logging.StreamHandler',
+        'stream': 'ext://sys.stdout',
+        'formatter': 'default'
+    }},
+    'root': {
+        'level': 'INFO',
+        'handlers': ['wsgi']
+    }
+})
+
+dictConfig({
+    'version': 1,
+    'formatters': {'default': {
+        'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+    }},
+    'handlers': {'wsgi': {
+        'class': 'logging.StreamHandler',
+        'stream': 'ext://sys.stdout',
+        'formatter': 'default'
+    }},
+    'root': {
+        'level': 'INFO',
+        'handlers': ['wsgi']
+    }
+})
 app = Flask(__name__)
 
 color_codes = {
@@ -24,10 +58,15 @@ COLOR_FROM_ENV = os.environ.get('APP_COLOR')
 COLOR = random.choice(["red", "green", "blue", "blue2", "darkblue", "pink"])
 
 
-@app.route("/")
+@app.route('/')
 def main():
-    # return 'Hello'
     return render_template('hello.html', color=color_codes[COLOR])
+
+
+@app.route('/error')
+def error():
+    app.logger.error("It's intentional error.")
+    return render_template('error.html')
 
 
 if __name__ == "__main__":

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>サンプルアプリケーション</title>
+<body style="background: red"></body>
+<div
+  style="
+    color: #e4e4e4;
+    text-align: center;
+    height: 90px;
+    vertical-align: middle;
+  "
+>
+  <h1>Sorry.Something went wrong..</h1>
+</div>


### PR DESCRIPTION
Closes #12 

## 何をやったか

- エラーログをサブスクリプションできるように、意図的にエラーログを出力するためのルートを追加

stdoutに以下の様に出力する

```
[2022-01-23 01:18:02,336] INFO in _internal: 172.17.0.1 - - [23/Jan/2022 01:18:02] "GET / HTTP/1.1" 200 -
[2022-01-23 01:18:07,412] ERROR in app: It's intentional error.
```